### PR TITLE
feat: add flash card feature

### DIFF
--- a/app/api/flashcards/[id]/review/route.ts
+++ b/app/api/flashcards/[id]/review/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { flashCardsDB } from '@/lib/flashcards-db';
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const card = await flashCardsDB.incrementReviewCount(params.id);
+    
+    if (!card) {
+      return NextResponse.json(
+        { error: 'Flashcard not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(card);
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to update review count' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/flashcards/[id]/route.ts
+++ b/app/api/flashcards/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { flashCardsDB } from '@/lib/flashcards-db';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const card = await flashCardsDB.getById(params.id);
+    
+    if (!card) {
+      return NextResponse.json(
+        { error: 'Flashcard not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(card);
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to fetch flashcard' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body = await request.json();
+    const updatedCard = await flashCardsDB.update(params.id, body);
+
+    if (!updatedCard) {
+      return NextResponse.json(
+        { error: 'Flashcard not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(updatedCard);
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to update flashcard' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const deleted = await flashCardsDB.delete(params.id);
+
+    if (!deleted) {
+      return NextResponse.json(
+        { error: 'Flashcard not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to delete flashcard' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/flashcards/route.ts
+++ b/app/api/flashcards/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { flashCardsDB } from '@/lib/flashcards-db';
+
+export async function GET() {
+  try {
+    const flashCards = await flashCardsDB.getAll();
+    return NextResponse.json(flashCards);
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to fetch flashcards' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { word, imageUrl, meaning, example, category, difficulty } = body;
+
+    if (!word || !meaning || !example) {
+      return NextResponse.json(
+        { error: 'Word, meaning, and example are required' },
+        { status: 400 }
+      );
+    }
+
+    const newCard = await flashCardsDB.create({
+      word,
+      imageUrl,
+      meaning,
+      example,
+      category,
+      difficulty: difficulty || 'medium',
+      lastReviewed: undefined
+    });
+
+    return NextResponse.json(newCard, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to create flashcard' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/flashcards/new/page.tsx
+++ b/app/flashcards/new/page.tsx
@@ -1,0 +1,24 @@
+import FlashCardForm from '@/components/FlashCardForm';
+import Link from 'next/link';
+
+export default function NewFlashCardPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <Link
+            href="/flashcards"
+            className="text-indigo-600 hover:text-indigo-500 mb-4 inline-block"
+          >
+            ← Back to Flashcards
+          </Link>
+          <h1 className="text-3xl font-bold text-gray-900">Create New Flashcard</h1>
+        </div>
+        
+        <div className="bg-white rounded-lg shadow p-6">
+          <FlashCardForm />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/flashcards/page.tsx
+++ b/app/flashcards/page.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { FlashCard as FlashCardType } from '@/lib/types';
+
+export default function FlashCardsPage() {
+  const [flashCards, setFlashCards] = useState<FlashCardType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<'all' | 'easy' | 'medium' | 'hard'>('all');
+
+  useEffect(() => {
+    fetchFlashCards();
+  }, []);
+
+  const fetchFlashCards = async () => {
+    try {
+      const response = await fetch('/api/flashcards');
+      const data = await response.json();
+      setFlashCards(data);
+    } catch (error) {
+      console.error('Failed to fetch flashcards:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this flashcard?')) return;
+
+    try {
+      const response = await fetch(`/api/flashcards/${id}`, {
+        method: 'DELETE',
+      });
+
+      if (response.ok) {
+        setFlashCards(flashCards.filter(card => card.id !== id));
+      }
+    } catch (error) {
+      console.error('Failed to delete flashcard:', error);
+    }
+  };
+
+  const filteredCards = filter === 'all' 
+    ? flashCards 
+    : flashCards.filter(card => card.difficulty === filter);
+
+  const getDifficultyColor = (difficulty: string) => {
+    switch (difficulty) {
+      case 'easy': return 'bg-green-100 text-green-800';
+      case 'medium': return 'bg-yellow-100 text-yellow-800';
+      case 'hard': return 'bg-red-100 text-red-800';
+      default: return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-gray-500">Loading flashcards...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">My Flashcards</h1>
+          <div className="flex gap-4">
+            <Link
+              href="/flashcards/study"
+              className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700"
+            >
+              Study Mode
+            </Link>
+            <Link
+              href="/flashcards/new"
+              className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700"
+            >
+              Add New Card
+            </Link>
+          </div>
+        </div>
+
+        <div className="mb-6 flex gap-2">
+          <button
+            onClick={() => setFilter('all')}
+            className={`px-4 py-2 rounded-md ${filter === 'all' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-700 border'}`}
+          >
+            All ({flashCards.length})
+          </button>
+          <button
+            onClick={() => setFilter('easy')}
+            className={`px-4 py-2 rounded-md ${filter === 'easy' ? 'bg-green-600 text-white' : 'bg-white text-gray-700 border'}`}
+          >
+            Easy ({flashCards.filter(c => c.difficulty === 'easy').length})
+          </button>
+          <button
+            onClick={() => setFilter('medium')}
+            className={`px-4 py-2 rounded-md ${filter === 'medium' ? 'bg-yellow-600 text-white' : 'bg-white text-gray-700 border'}`}
+          >
+            Medium ({flashCards.filter(c => c.difficulty === 'medium').length})
+          </button>
+          <button
+            onClick={() => setFilter('hard')}
+            className={`px-4 py-2 rounded-md ${filter === 'hard' ? 'bg-red-600 text-white' : 'bg-white text-gray-700 border'}`}
+          >
+            Hard ({flashCards.filter(c => c.difficulty === 'hard').length})
+          </button>
+        </div>
+
+        {filteredCards.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-gray-500 mb-4">No flashcards found.</p>
+            <Link
+              href="/flashcards/new"
+              className="text-indigo-600 hover:text-indigo-500"
+            >
+              Create your first flashcard
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredCards.map(card => (
+              <div key={card.id} className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+                <div className="flex justify-between items-start mb-4">
+                  <h3 className="text-xl font-semibold text-gray-900">{card.word}</h3>
+                  <span className={`px-2 py-1 rounded-full text-xs font-medium ${getDifficultyColor(card.difficulty)}`}>
+                    {card.difficulty}
+                  </span>
+                </div>
+                
+                {card.imageUrl && (
+                  <img
+                    src={card.imageUrl}
+                    alt={card.word}
+                    className="w-full h-32 object-cover rounded mb-4"
+                  />
+                )}
+                
+                <p className="text-gray-600 mb-4 line-clamp-2">{card.meaning}</p>
+                
+                {card.category && (
+                  <p className="text-sm text-gray-500 mb-4">Category: {card.category}</p>
+                )}
+                
+                <div className="flex justify-between items-center">
+                  <span className="text-sm text-gray-500">
+                    Reviews: {card.reviewCount}
+                  </span>
+                  <div className="flex gap-2">
+                    <Link
+                      href={`/flashcards/${card.id}/edit`}
+                      className="text-indigo-600 hover:text-indigo-500 text-sm"
+                    >
+                      Edit
+                    </Link>
+                    <button
+                      onClick={() => handleDelete(card.id)}
+                      className="text-red-600 hover:text-red-500 text-sm"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/flashcards/study/page.tsx
+++ b/app/flashcards/study/page.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import FlashCard from '@/components/FlashCard';
+import { FlashCard as FlashCardType } from '@/lib/types';
+
+export default function StudyPage() {
+  const [flashCards, setFlashCards] = useState<FlashCardType[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [studyMode, setStudyMode] = useState<'sequential' | 'random'>('sequential');
+
+  useEffect(() => {
+    fetchFlashCards();
+  }, []);
+
+  const fetchFlashCards = async () => {
+    try {
+      const response = await fetch('/api/flashcards');
+      const data = await response.json();
+      setFlashCards(data);
+      
+      if (studyMode === 'random' && data.length > 0) {
+        setCurrentIndex(Math.floor(Math.random() * data.length));
+      }
+    } catch (error) {
+      console.error('Failed to fetch flashcards:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReview = async () => {
+    if (flashCards[currentIndex]) {
+      try {
+        await fetch(`/api/flashcards/${flashCards[currentIndex].id}/review`, {
+          method: 'POST',
+        });
+      } catch (error) {
+        console.error('Failed to update review count:', error);
+      }
+    }
+  };
+
+  const goToNext = () => {
+    if (studyMode === 'random') {
+      const nextIndex = Math.floor(Math.random() * flashCards.length);
+      setCurrentIndex(nextIndex);
+    } else {
+      setCurrentIndex((prev) => (prev + 1) % flashCards.length);
+    }
+  };
+
+  const goToPrevious = () => {
+    if (studyMode === 'random') {
+      const prevIndex = Math.floor(Math.random() * flashCards.length);
+      setCurrentIndex(prevIndex);
+    } else {
+      setCurrentIndex((prev) => (prev - 1 + flashCards.length) % flashCards.length);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-gray-500">Loading flashcards...</div>
+      </div>
+    );
+  }
+
+  if (flashCards.length === 0) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-gray-500 mb-4">No flashcards available to study.</p>
+          <Link
+            href="/flashcards/new"
+            className="text-indigo-600 hover:text-indigo-500"
+          >
+            Create your first flashcard
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const currentCard = flashCards[currentIndex];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-50 to-purple-50 py-8">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-8 flex justify-between items-center">
+          <Link
+            href="/flashcards"
+            className="text-indigo-600 hover:text-indigo-500"
+          >
+            ← Back to Flashcards
+          </Link>
+          
+          <div className="flex items-center gap-4">
+            <span className="text-gray-600">
+              Card {currentIndex + 1} of {flashCards.length}
+            </span>
+            
+            <select
+              value={studyMode}
+              onChange={(e) => setStudyMode(e.target.value as 'sequential' | 'random')}
+              className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"
+            >
+              <option value="sequential">Sequential</option>
+              <option value="random">Random</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="mb-8">
+          <FlashCard card={currentCard} onReview={handleReview} />
+        </div>
+
+        <div className="flex justify-between items-center">
+          <button
+            onClick={goToPrevious}
+            className="bg-white text-gray-700 px-6 py-3 rounded-lg shadow hover:shadow-md transition-shadow border border-gray-200"
+          >
+            ← Previous
+          </button>
+
+          <div className="flex gap-2">
+            {flashCards.map((_, index) => (
+              <button
+                key={index}
+                onClick={() => setCurrentIndex(index)}
+                className={`w-2 h-2 rounded-full transition-colors ${
+                  index === currentIndex ? 'bg-indigo-600' : 'bg-gray-300'
+                }`}
+              />
+            ))}
+          </div>
+
+          <button
+            onClick={goToNext}
+            className="bg-white text-gray-700 px-6 py-3 rounded-lg shadow hover:shadow-md transition-shadow border border-gray-200"
+          >
+            Next →
+          </button>
+        </div>
+
+        <div className="mt-8 text-center">
+          <p className="text-sm text-gray-600">
+            Tip: Click on the card to flip and see the meaning and example
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,26 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.perspective-1000 {
+  perspective: 1000px;
+}
+
+.transform-style-preserve-3d {
+  transform-style: preserve-3d;
+}
+
+.backface-hidden {
+  backface-visibility: hidden;
+}
+
+.rotate-y-180 {
+  transform: rotateY(180deg);
+}
+
+.line-clamp-2 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,12 @@ export default function Home() {
           >
             Go to Dashboard
           </Link>
+          <Link
+            href="/flashcards"
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+          >
+            Study Flashcards
+          </Link>
         </div>
       </div>
     </div>

--- a/components/DashboardClient.tsx
+++ b/components/DashboardClient.tsx
@@ -69,8 +69,11 @@ export default function DashboardClient() {
       <nav className="bg-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
-            <div className="flex items-center">
+            <div className="flex items-center gap-6">
               <h1 className="text-xl font-semibold">Dashboard</h1>
+              <a href="/flashcards" className="text-indigo-600 hover:text-indigo-500">
+                Flashcards
+              </a>
             </div>
             <div className="flex items-center space-x-4">
               <span className="text-gray-700">Welcome, {user.name}</span>

--- a/components/FlashCard.tsx
+++ b/components/FlashCard.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { FlashCard as FlashCardType } from '@/lib/types';
+
+interface FlashCardProps {
+  card: FlashCardType;
+  onReview?: () => void;
+}
+
+export default function FlashCard({ card, onReview }: FlashCardProps) {
+  const [isFlipped, setIsFlipped] = useState(false);
+
+  const handleFlip = () => {
+    setIsFlipped(!isFlipped);
+    if (!isFlipped && onReview) {
+      onReview();
+    }
+  };
+
+  const getDifficultyColor = (difficulty: string) => {
+    switch (difficulty) {
+      case 'easy': return 'bg-green-100 text-green-800';
+      case 'medium': return 'bg-yellow-100 text-yellow-800';
+      case 'hard': return 'bg-red-100 text-red-800';
+      default: return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  return (
+    <div className="relative w-full h-96 perspective-1000">
+      <div
+        className={`absolute inset-0 w-full h-full transition-transform duration-700 transform-style-preserve-3d cursor-pointer ${
+          isFlipped ? 'rotate-y-180' : ''
+        }`}
+        onClick={handleFlip}
+      >
+        {/* Front of card */}
+        <div className="absolute inset-0 w-full h-full backface-hidden rounded-xl shadow-lg bg-white border border-gray-200">
+          <div className="flex flex-col h-full p-6">
+            <div className="flex justify-between items-start mb-4">
+              <span className={`px-3 py-1 rounded-full text-xs font-medium ${getDifficultyColor(card.difficulty)}`}>
+                {card.difficulty}
+              </span>
+              {card.category && (
+                <span className="text-sm text-gray-500">{card.category}</span>
+              )}
+            </div>
+            
+            <div className="flex-1 flex flex-col items-center justify-center">
+              {card.imageUrl && (
+                <img
+                  src={card.imageUrl}
+                  alt={card.word}
+                  className="w-48 h-48 object-cover rounded-lg mb-6 shadow-md"
+                />
+              )}
+              <h2 className="text-3xl font-bold text-gray-900">{card.word}</h2>
+            </div>
+            
+            <div className="text-center text-sm text-gray-500">
+              Click to flip
+            </div>
+          </div>
+        </div>
+
+        {/* Back of card */}
+        <div className="absolute inset-0 w-full h-full backface-hidden rounded-xl shadow-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white rotate-y-180">
+          <div className="flex flex-col h-full p-6">
+            <div className="flex justify-between items-start mb-6">
+              <h3 className="text-2xl font-bold">{card.word}</h3>
+              <span className="text-sm opacity-75">
+                Reviews: {card.reviewCount}
+              </span>
+            </div>
+            
+            <div className="flex-1 space-y-6">
+              <div>
+                <h4 className="text-sm font-medium opacity-75 mb-2">Meaning:</h4>
+                <p className="text-lg">{card.meaning}</p>
+              </div>
+              
+              <div>
+                <h4 className="text-sm font-medium opacity-75 mb-2">Example:</h4>
+                <p className="italic">{card.example}</p>
+              </div>
+            </div>
+            
+            <div className="text-center text-sm opacity-75">
+              Click to flip back
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/FlashCardForm.tsx
+++ b/components/FlashCardForm.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function FlashCardForm() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [formData, setFormData] = useState({
+    word: '',
+    imageUrl: '',
+    meaning: '',
+    example: '',
+    category: '',
+    difficulty: 'medium' as 'easy' | 'medium' | 'hard'
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const response = await fetch('/api/flashcards', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to create flashcard');
+      }
+
+      router.push('/flashcards');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-2xl mx-auto">
+      <div>
+        <label htmlFor="word" className="block text-sm font-medium text-gray-700">
+          Word *
+        </label>
+        <input
+          type="text"
+          name="word"
+          id="word"
+          required
+          value={formData.word}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"
+          placeholder="Enter the word to learn"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="imageUrl" className="block text-sm font-medium text-gray-700">
+          Image URL (optional)
+        </label>
+        <input
+          type="url"
+          name="imageUrl"
+          id="imageUrl"
+          value={formData.imageUrl}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"
+          placeholder="https://example.com/image.jpg"
+        />
+        {formData.imageUrl && (
+          <div className="mt-2">
+            <img src={formData.imageUrl} alt="Preview" className="h-32 w-32 object-cover rounded" />
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="meaning" className="block text-sm font-medium text-gray-700">
+          Meaning *
+        </label>
+        <textarea
+          name="meaning"
+          id="meaning"
+          required
+          rows={3}
+          value={formData.meaning}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"
+          placeholder="Enter the meaning or definition"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="example" className="block text-sm font-medium text-gray-700">
+          Example *
+        </label>
+        <textarea
+          name="example"
+          id="example"
+          required
+          rows={2}
+          value={formData.example}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"
+          placeholder="Enter an example sentence"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="category" className="block text-sm font-medium text-gray-700">
+            Category (optional)
+          </label>
+          <input
+            type="text"
+            name="category"
+            id="category"
+            value={formData.category}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"
+            placeholder="e.g., Vocabulary, Grammar"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="difficulty" className="block text-sm font-medium text-gray-700">
+            Difficulty
+          </label>
+          <select
+            name="difficulty"
+            id="difficulty"
+            value={formData.difficulty}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"
+          >
+            <option value="easy">Easy</option>
+            <option value="medium">Medium</option>
+            <option value="hard">Hard</option>
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-red-50 p-4">
+          <p className="text-sm text-red-800">{error}</p>
+        </div>
+      )}
+
+      <div className="flex gap-4">
+        <button
+          type="submit"
+          disabled={loading}
+          className="flex-1 bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? 'Creating...' : 'Create Flashcard'}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push('/flashcards')}
+          className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/lib/flashcards-db.ts
+++ b/lib/flashcards-db.ts
@@ -1,0 +1,88 @@
+import { FlashCard } from './types';
+
+let flashCards: FlashCard[] = [
+  {
+    id: '1',
+    word: 'Serendipity',
+    imageUrl: 'https://images.unsplash.com/photo-1513151233558-d860c5398176?w=400',
+    meaning: 'The occurrence of finding pleasant things by chance',
+    example: 'Finding that coffee shop was pure serendipity - it became my favorite place to work.',
+    category: 'Advanced Vocabulary',
+    createdAt: new Date('2024-01-01'),
+    reviewCount: 0,
+    difficulty: 'hard'
+  },
+  {
+    id: '2',
+    word: 'Ephemeral',
+    imageUrl: 'https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=400',
+    meaning: 'Lasting for a very short time',
+    example: 'The beauty of cherry blossoms is ephemeral, lasting only a few weeks each spring.',
+    category: 'Advanced Vocabulary',
+    createdAt: new Date('2024-01-02'),
+    reviewCount: 0,
+    difficulty: 'medium'
+  },
+  {
+    id: '3',
+    word: 'Resilient',
+    imageUrl: 'https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=400',
+    meaning: 'Able to recover quickly from difficult conditions',
+    example: 'Despite many setbacks, she remained resilient and achieved her goals.',
+    category: 'Personal Development',
+    createdAt: new Date('2024-01-03'),
+    reviewCount: 0,
+    difficulty: 'easy'
+  }
+];
+
+export const flashCardsDB = {
+  getAll: async (): Promise<FlashCard[]> => {
+    return [...flashCards].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  },
+
+  getById: async (id: string): Promise<FlashCard | null> => {
+    return flashCards.find(card => card.id === id) || null;
+  },
+
+  create: async (data: Omit<FlashCard, 'id' | 'createdAt' | 'reviewCount'>): Promise<FlashCard> => {
+    const newCard: FlashCard = {
+      ...data,
+      id: Date.now().toString(),
+      createdAt: new Date(),
+      reviewCount: 0
+    };
+    flashCards.push(newCard);
+    return newCard;
+  },
+
+  update: async (id: string, data: Partial<FlashCard>): Promise<FlashCard | null> => {
+    const index = flashCards.findIndex(card => card.id === id);
+    if (index === -1) return null;
+    
+    flashCards[index] = {
+      ...flashCards[index],
+      ...data,
+      id: flashCards[index].id,
+      createdAt: flashCards[index].createdAt
+    };
+    return flashCards[index];
+  },
+
+  delete: async (id: string): Promise<boolean> => {
+    const index = flashCards.findIndex(card => card.id === id);
+    if (index === -1) return false;
+    
+    flashCards.splice(index, 1);
+    return true;
+  },
+
+  incrementReviewCount: async (id: string): Promise<FlashCard | null> => {
+    const card = flashCards.find(c => c.id === id);
+    if (!card) return null;
+    
+    card.reviewCount++;
+    card.lastReviewed = new Date();
+    return card;
+  }
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,21 @@
+export interface FlashCard {
+  id: string;
+  word: string;
+  imageUrl?: string;
+  meaning: string;
+  example: string;
+  category?: string;
+  createdAt: Date;
+  lastReviewed?: Date;
+  reviewCount: number;
+  difficulty: 'easy' | 'medium' | 'hard';
+}
+
+export interface FlashCardFormData {
+  word: string;
+  imageUrl?: string;
+  meaning: string;
+  example: string;
+  category?: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+}


### PR DESCRIPTION
This pull request introduces a complete flashcard study feature, including backend API endpoints and frontend pages for creating, viewing, studying, and managing flashcards. It also adds a reusable flashcard component with a flip animation and updates navigation to integrate the flashcard functionality throughout the app.

**Backend API endpoints for flashcards:**

- Added RESTful API routes for flashcards, supporting fetching all cards, creating a new card, retrieving, updating, and deleting a single card, and incrementing the review count for studying (`app/api/flashcards/route.ts`, `app/api/flashcards/[id]/route.ts`, `app/api/flashcards/[id]/review/route.ts`). ([app/api/flashcards/route.tsR1-R45](diffhunk://#diff-672671f5dee160c8e6840d2ff0ed1dffeaf9359e54b620257dee97b26b50d517R1-R45), [app/api/flashcards/[id]/route.tsR1-R72](diffhunk://#diff-374cb861952cdbbd4fc6ff7ed3f7ea1a749ad891b62f4ef2d2bd9dff0ac16b8dR1-R72), [app/api/flashcards/[id]/review/route.tsR1-R25](diffhunk://#diff-00de706833946238ffa1337f7e0d622f6d479abfe7ca64cd6b143b6ed53a8aa8R1-R25))

**Frontend pages for flashcard management and study:**

- Added a flashcard list page with filtering, creation, editing, and deletion capabilities (`app/flashcards/page.tsx`).
- Added a page for creating new flashcards with a form (`app/flashcards/new/page.tsx`).
- Added a study mode page allowing sequential or random review of flashcards, with review count tracking (`app/flashcards/study/page.tsx`).

**Reusable flashcard component:**

- Implemented a `FlashCard` component with a 3D flip animation, displaying word, image, meaning, example, and review count (`components/FlashCard.tsx`).
- Added supporting CSS classes for 3D flip effect and text clamping (`app/globals.css`).

**Navigation and integration:**

- Updated the main page and dashboard to link to the flashcards section, making the feature discoverable (`app/page.tsx`, `components/DashboardClient.tsx`). [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R24-R29) [[2]](diffhunk://#diff-7c68c42d47ff9cdb18849b815828cac99953b333df262df2e302b367cd88ce71L72-R76)